### PR TITLE
migrate_to_ar: cope with the database path changing

### DIFF
--- a/AR-MIGRATE.md
+++ b/AR-MIGRATE.md
@@ -7,11 +7,10 @@ If you've used this application before it switched to using ActiveRecord
 you need to do the following steps to migrate the data and generate the new
 table structures.
 
-Even though the migration script will create a backup of your database, it is
-probably best to create a backup yourself.
+Even though the migration script will import to a new database file at a
+different path, it is probably best to create a backup yourself.
 You can also copy the `db/production.sqlite3` to your local machine and do the
 migration there.
-
 After a successful migration you'd have to copy the updated database file back
 to the production machine.
 
@@ -27,20 +26,23 @@ Now you are ready to do the migration:
 
 	bundle exec ruby tools/migrate_to_ar.rb -e production
 
-The -e switch allows you to select the correct database environment from
+The `-e` switch allows you to select the correct database environment from
 `db/config.yml`.
+
 The migration script will:
 
-	- dump the contents of the database to a YAML file
-	- rename the original database file to `production.sqlite3.#{Time.now.to_i}`
-	- create the database using ActiveRecord migrations
-	- load the contents from the dump file
+	- dump the contents of the old database (most likely at
+      `db/production.sqlite`) to a temporary YAML file
+	- create the new database at `db/production/production.sqlite3` using
+      ActiveRecord migrations
+	- import the contents from the dump file
 	- remove the dump file
 
-Now your data is completely migrated and the library will now use ActiveRecord
-to handle anything database related.
+Now your data is completely migrated into a new database at the new recommended
+path, and the library will now use ActiveRecord to handle anything database
+related.
 
-Note: The ActiveRecord migration also defaults to putting the production
-database files in `db/production/` instead of just `db/`, which allows for
-a separate user to be able to write to the SQLite file without writing to
-`db/config.yml` and `db/migrate/` files.
+It is recommended to follow the
+[initial installation instructions](https://github.com/jcs/rubywarden#usage)
+to create a new, unprivileged user to own the new `db/production/` database
+and run the server.


### PR DESCRIPTION
Assume we just have a database at the old path
db/production.sqlite3, then dump that to the YAML file.

Then run the migration which will create the new, blank database at
db/production/production.sqlite3, which we will then import the YAML
file to.

Fixes #63